### PR TITLE
scss: Fix ordered list position + margin

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -57,6 +57,10 @@ ul {
 	}
 }
 
+.wrapper ol {
+    margin-bottom: 15px;
+    padding-left: 30px;
+}
 
 .header {
 	display: flex;


### PR DESCRIPTION
- Move the numbers inside the div tag instead of in padding of wrapper.
- Apply footer margin matching that of the `<p>` tag.
- Before: http://i.imgur.com/CTyDDSt.png
- After: http://i.imgur.com/poduze4.png
